### PR TITLE
Fixed adhoc crash in onKeyPress when leaving ESGX previewer

### DIFF
--- a/src/projects/gt6/dev_runviewer/SoundMenu.ad
+++ b/src/projects/gt6/dev_runviewer/SoundMenu.ad
@@ -130,11 +130,26 @@ module SoundMenu
         DialogUtil::openConfirmDialog(context, DialogUtil::OK, info);
     }
 
-    function on_init_engine_list_10000(context, index, menuitem, item, menu)
+    function on_init_engine_list_100000(context, index, menuitem, item, menu)
     {
         var base = 0;
         var items = Array();
-        for (var i = 0; i <= 9; i++)
+        for (var i = 0; i <= 3; i++)
+        {
+            var entry = "%05d".format(base + (i * 100000));
+            var menu = MenuItem(MenuItemTEXT, entry, nil, nil, nil, on_init_engine_list_10000);
+            menu.arg = menuitem.label;
+            items.push(menu);
+        }
+
+        open_menu(context, menuitem.label, items, index, 0);
+    }
+
+    function on_init_engine_list_10000(context, index, menuitem, item, menu)
+    {
+        var base = menuitem.label.toInt();
+        var items = Array();
+        for (var i = 0; i < 10; i++)
         {
             var entry = "%05d".format(base + (i * 10000));
             var menu = MenuItem(MenuItemTEXT, entry, nil, nil, nil, on_init_engine_list_01000);
@@ -147,7 +162,7 @@ module SoundMenu
 
     function on_select_car_sound_previewer_by_id(context, index, menuitem, item, menu)
     {
-        on_init_engine_list_10000(context, index, menuitem, item, menu);
+        on_init_engine_list_100000(context, index, menuitem, item, menu);
     }
 
     function on_init_engine_list_01000(context, index, menuitem, item, menu)
@@ -333,7 +348,6 @@ module SoundMenu
             case "turbo1":
             case "turbo2":
             case "turbo3":
-                push_menu_stack(context, index);
                 var project = main::manager.loadProject("/" + main::PROJECT_ROOT_DIR + "/dev_sound/dev_sound");
                 finally() => { main::manager.unloadProject(project); }
 
@@ -430,7 +444,6 @@ module SoundMenu
         var label = menuitem.label;
         var cp = gtengine::MCarParameter(label);
         var a = cp.getSoundID();
-        push_menu_stack(context, index);
 
         SoundProject::EngineSoundRoot::open(context, a[0], muffler_type_dispnames[a[1]]);
     }
@@ -618,9 +631,9 @@ module SoundMenu
 
     static sound_previewer_top_menu = [
         gray, 
-        MenuItem(MenuItemTEXT, "サウンド・ポップアップメニュー", "", nil, nil, on_select_sound_debug_popup_menu),
-        MenuItem(MenuItemTEXT, "エンジン／ホーンサウンドプレビュー（ID 選択）", "", nil, nil, on_select_car_sound_previewer_by_id),
-        MenuItem(MenuItemTEXT, "エンジン／ホーンサウンドプレビュー（カーコード選択）", "", nil, nil, on_select_car_sound_previewer_by_carcode),
+        MenuItem(MenuItemTEXT, "dev_sound", "", nil, nil, on_select_sound_debug_popup_menu),
+        MenuItem(MenuItemTEXT, "Car Sound Previewer (By soundNum)", "", nil, nil, on_select_car_sound_previewer_by_id),
+        MenuItem(MenuItemTEXT, "Car Sound Previewer (By Car Label)", "", nil, nil, on_select_car_sound_previewer_by_carcode),
         MenuItem(MenuItemTEXT, "ESGX Player: squeal2.esgx", "", nil, nil, on_select_es_previewer, nil, "sound_gt/se/squeal2"),
         MenuItem(MenuItemTEXT, "ESGX Player: squeal3.esgx", "", nil, nil, on_select_es_previewer, nil, "sound_gt/se/squeal3"),
         MenuItem(MenuItemTEXT, "ESGX Player: squeal4.esgx", "", nil, nil, on_select_es_previewer, nil, "sound_gt/se/squeal4"),
@@ -629,8 +642,8 @@ module SoundMenu
         MenuItem(MenuItemTEXT, "サウンドデバッグモード", "サウンドのデバッグ用にビジュアライザを表示します", nil, on_update_sound_debug_mode, on_activate_sound_debug_mode),
         MenuItem(MenuItemTEXT, "サウンドダイレクト出力モード", "BGM, SE の音量を、原音の 100% のレベルで出力するテストモードです（開発時の音量確認用）", nil, on_update_audio_direct_mode, on_activate_audio_direct_mode),
         MenuItem(MenuItemTEXT, "現在のシステム音声出力の情報", "", nil, nil, on_select_audio_output_info),
-        MenuItem(MenuItemTEXT, "エンジン音ファイルチェック（ダイアログ）", "", nil, nil, on_carsound_file_check),
-        MenuItem(MenuItemTEXT, "エンジン音ファイルチェック（ログに出力）", "", nil, nil, on_carsound_file_check_dump),
+        MenuItem(MenuItemTEXT, "Check for missing/oversized sound files", "", nil, nil, on_carsound_file_check),
+        MenuItem(MenuItemTEXT, "Log missing/oversized sound files", "", nil, nil, on_carsound_file_check_dump),
         select_car_list_menuitem,
         MenuItem(MenuItemTEXT, "Horn Sound File Check (Dump)", "", nil, nil, on_horn_file_check_dump),
         RunviewerUtil::CreateFileExplorer("sound_gt/guide/gt5", on_select_pacenote, "", "GT5 Voice Guidance Player", "", nil)

--- a/src/projects/gt6/dev_runviewer/SoundMenu.ad
+++ b/src/projects/gt6/dev_runviewer/SoundMenu.ad
@@ -130,26 +130,11 @@ module SoundMenu
         DialogUtil::openConfirmDialog(context, DialogUtil::OK, info);
     }
 
-    function on_init_engine_list_100000(context, index, menuitem, item, menu)
+    function on_init_engine_list_10000(context, index, menuitem, item, menu)
     {
         var base = 0;
         var items = Array();
-        for (var i = 0; i <= 3; i++)
-        {
-            var entry = "%05d".format(base + (i * 100000));
-            var menu = MenuItem(MenuItemTEXT, entry, nil, nil, nil, on_init_engine_list_10000);
-            menu.arg = menuitem.label;
-            items.push(menu);
-        }
-
-        open_menu(context, menuitem.label, items, index, 0);
-    }
-
-    function on_init_engine_list_10000(context, index, menuitem, item, menu)
-    {
-        var base = menuitem.label.toInt();
-        var items = Array();
-        for (var i = 0; i < 10; i++)
+        for (var i = 0; i <= 9; i++)
         {
             var entry = "%05d".format(base + (i * 10000));
             var menu = MenuItem(MenuItemTEXT, entry, nil, nil, nil, on_init_engine_list_01000);
@@ -162,7 +147,7 @@ module SoundMenu
 
     function on_select_car_sound_previewer_by_id(context, index, menuitem, item, menu)
     {
-        on_init_engine_list_100000(context, index, menuitem, item, menu);
+        on_init_engine_list_10000(context, index, menuitem, item, menu);
     }
 
     function on_init_engine_list_01000(context, index, menuitem, item, menu)
@@ -631,9 +616,9 @@ module SoundMenu
 
     static sound_previewer_top_menu = [
         gray, 
-        MenuItem(MenuItemTEXT, "dev_sound", "", nil, nil, on_select_sound_debug_popup_menu),
-        MenuItem(MenuItemTEXT, "Car Sound Previewer (By soundNum)", "", nil, nil, on_select_car_sound_previewer_by_id),
-        MenuItem(MenuItemTEXT, "Car Sound Previewer (By Car Label)", "", nil, nil, on_select_car_sound_previewer_by_carcode),
+        MenuItem(MenuItemTEXT, "サウンド・ポップアップメニュー", "", nil, nil, on_select_sound_debug_popup_menu),
+        MenuItem(MenuItemTEXT, "エンジン／ホーンサウンドプレビュー（ID 選択）", "", nil, nil, on_select_car_sound_previewer_by_id),
+        MenuItem(MenuItemTEXT, "エンジン／ホーンサウンドプレビュー（カーコード選択）", "", nil, nil, on_select_car_sound_previewer_by_carcode),
         MenuItem(MenuItemTEXT, "ESGX Player: squeal2.esgx", "", nil, nil, on_select_es_previewer, nil, "sound_gt/se/squeal2"),
         MenuItem(MenuItemTEXT, "ESGX Player: squeal3.esgx", "", nil, nil, on_select_es_previewer, nil, "sound_gt/se/squeal3"),
         MenuItem(MenuItemTEXT, "ESGX Player: squeal4.esgx", "", nil, nil, on_select_es_previewer, nil, "sound_gt/se/squeal4"),
@@ -642,8 +627,8 @@ module SoundMenu
         MenuItem(MenuItemTEXT, "サウンドデバッグモード", "サウンドのデバッグ用にビジュアライザを表示します", nil, on_update_sound_debug_mode, on_activate_sound_debug_mode),
         MenuItem(MenuItemTEXT, "サウンドダイレクト出力モード", "BGM, SE の音量を、原音の 100% のレベルで出力するテストモードです（開発時の音量確認用）", nil, on_update_audio_direct_mode, on_activate_audio_direct_mode),
         MenuItem(MenuItemTEXT, "現在のシステム音声出力の情報", "", nil, nil, on_select_audio_output_info),
-        MenuItem(MenuItemTEXT, "Check for missing/oversized sound files", "", nil, nil, on_carsound_file_check),
-        MenuItem(MenuItemTEXT, "Log missing/oversized sound files", "", nil, nil, on_carsound_file_check_dump),
+        MenuItem(MenuItemTEXT, "エンジン音ファイルチェック（ダイアログ）", "", nil, nil, on_carsound_file_check),
+        MenuItem(MenuItemTEXT, "エンジン音ファイルチェック（ログに出力）", "", nil, nil, on_carsound_file_check_dump),
         select_car_list_menuitem,
         MenuItem(MenuItemTEXT, "Horn Sound File Check (Dump)", "", nil, nil, on_horn_file_check_dump),
         RunviewerUtil::CreateFileExplorer("sound_gt/guide/gt5", on_select_pacenote, "", "GT5 Voice Guidance Player", "", nil)

--- a/src/projects/gt6/race_freerun/QuickRoot.ad
+++ b/src/projects/gt6/race_freerun/QuickRoot.ad
@@ -196,6 +196,66 @@ module QuickRoot
         return STATE_YIELD;
     }
 
+    async function onChangeCar(context)
+    {
+        main::sound.play("ok");
+
+        QuickRoot.hideAction(context);
+
+        gSequenceCondition.loadProject("garage");
+        var garage_id = GarageProject::CarSelectPopup.openCarSelect(context);
+        if (garage_id != nil)
+        {
+            var cp = GAME_STATUS.user_profile.garage.getRidingCar();
+            cp.target = true;
+
+            var slot_id = getPlayerSlot();
+            var dp = getPlayerDriver();
+
+            ORG.openEntryRacer();
+            ORG.leaveRace(slot_id);
+            ORG.disableDirectStatus = false;
+            do 
+            {
+                await () => { Thread::Sleep(0.2); };
+            } while (ORG.getEntryState(slot_id) == gtengine::EntryLevel::RACER);
+
+            ORG.entryRaceRequest(slot_id);
+
+            if (ORG.checkAcceptRaceRequest(slot_id) == false)
+                return;
+
+            ORG.setRidingDriverIndex(slot_id, 0);
+
+            var account_id = 0;
+            RaceOperator.setAccountDriverParameter(account_id, 0, dp);
+            RaceOperator.setSlotCarParameter(slot_id, cp);
+            RaceOperator.storeAccountDriverParameter(account_id);
+
+            // No idea if these two are required
+            RaceOperator.setTargetCarParameter(slot_id, cp);
+            RaceOperator.setTargetDriverParameter(slot_id, dp);
+
+            ORG.setRidingDriverIndex(slot_id, 0);
+
+            var success = ORG.entryRaceAsync(slot_id, cp);
+            if (!success)
+                return;
+
+            do 
+            {
+                await () => { Thread::Sleep(0.2); };
+            } while (ORG.getEntryState(slot_id) != gtengine::EntryLevel::RACER);
+
+            ORG.closeEntryRacer();
+        }
+        gSequenceCondition.unloadProject("garage");
+
+        QuickRoot.appearAction(context);
+
+        return STATE_YIELD;
+    }
+
     method onSetting(context)
     {
         main::sound.play("ok");
@@ -471,6 +531,7 @@ module QuickRoot
                 icons.push(RaceMenuUtil::Icon("TUNE", "icon_setting.dds", onSetting));
             }
 
+            icons.push(RaceMenuUtil::Icon("CHANGE_CAR", "icon_setting.dds", onChangeCar));
             icons.push(RaceMenuUtil::Icon("COURSE_CONDITION", "icon_course_setting.dds", onCourseCondition));
 
         }


### PR DESCRIPTION
Repro: Go to the sound menu in dev_runviewer, either of the ESGX previewer branches, open a sound to go to the ESGX graph screen. When you return to the menu showing muffler levels, pressing any button will adhoc crash back to the top menu.

Cause: The functions that launch the ESGX previewer call push_menu_stack which adds a dummy StackUnit to the stack (literally titled "dummy"). When you return to the muffler menu, onKeyPress gets the current stack item which is the dummy rather than the actual current menu, and tries to access a nil menu_items attribute.

Fix: Just removing the calls to push_menu_stack in SoundMenu.adc seems to fix this - nothing else calls it and it doesn't seem to do anything useful, probably a leftover of some sort from PD testing